### PR TITLE
Sticky header

### DIFF
--- a/public/css/main.css
+++ b/public/css/main.css
@@ -168,8 +168,10 @@ pre>code {
 .site-header {
   border-top: 4px solid #781900;
   border-bottom: 1px solid #e8e8e8;
+  background-color: #fff;
   min-height: 46px;
-  position: relative
+  position: sticky;
+  top: 0;
 }
 
 .site-title {

--- a/src/components/layout/Footer.js
+++ b/src/components/layout/Footer.js
@@ -17,7 +17,7 @@ const Footer = (props) => {
         </div>
 
         <div className="footer-col footer-col-2">
-          <p>Based on the <a href="https://thebombzen.com/grimoire/" target="_blank" rel="noopener noreferrer">D&amp;D Grimoire</a> maintained by <a href="https://github.com/thebombzen/grimoire/" target="_blank" rel="noopener noreferrer">Leo Izen (thebombzen)</a></p> and originally concieved by <a href="https://github.com/ephe" target="_blank" rel="noopener noreferrer">Pauline C (ephe)</a>
+          <p>Based on the <a href="https://thebombzen.com/grimoire/" target="_blank" rel="noopener noreferrer">D&amp;D Grimoire</a> maintained by <a href="https://github.com/thebombzen/grimoire/" target="_blank" rel="noopener noreferrer">Leo Izen (thebombzen)</a> and originally concieved by <a href="https://github.com/ephe" target="_blank" rel="noopener noreferrer">Pauline C (ephe)</a></p> 
         </div>
       
       <div className="footer-col footer-col-3">

--- a/src/components/layout/Footer.js
+++ b/src/components/layout/Footer.js
@@ -17,7 +17,7 @@ const Footer = (props) => {
         </div>
 
         <div className="footer-col footer-col-2">
-          <p>Based on the <a href="https://thebombzen.com/grimoire/" target="_blank" rel="noopener noreferrer">D&amp;D Grimoire</a> maintained by <a href="https://github.com/thebombzen/grimoire/" target="_blank" rel="noopener noreferrer">thebombzen</a></p>
+          <p>Based on the <a href="https://thebombzen.com/grimoire/" target="_blank" rel="noopener noreferrer">D&amp;D Grimoire</a> maintained by <a href="https://github.com/thebombzen/grimoire/" target="_blank" rel="noopener noreferrer">Leo Izen (thebombzen)</a></p> and originally concieved by <a href="https://github.com/ephe" target="_blank" rel="noopener noreferrer">Pauline C (ephe)</a>
         </div>
       
       <div className="footer-col footer-col-3">

--- a/src/components/layout/Header.js
+++ b/src/components/layout/Header.js
@@ -19,7 +19,7 @@ const Header = (props) => {
           </button>
           <div id="menu" className="trigger">
           {sections.map((section, i) => {
-            return (<HashLink className="page-link" to={`/#${caseConverter(section.key).toLowerCase()}`} key={i}>{section.value}</HashLink>)
+            return (<HashLink className="page-link" to={`/#${caseConverter(section.key).toLowerCase()}`} scroll={el => {el.scrollIntoView();window.scrollBy(0,-83)}} key={i}>{section.value}</HashLink>)
           })}
           </div>
         </nav>

--- a/src/components/layout/Header.js
+++ b/src/components/layout/Header.js
@@ -19,7 +19,11 @@ const Header = (props) => {
           </button>
           <div id="menu" className="trigger">
           {sections.map((section, i) => {
-            return (<HashLink className="page-link" to={`/#${caseConverter(section.key).toLowerCase()}`} scroll={el => {el.scrollIntoView();window.scrollBy(0,-83)}} key={i}>{section.value}</HashLink>)
+            return (<HashLink className="page-link" to={`/#${caseConverter(section.key).toLowerCase()}`} scroll={el => {
+              el.scrollIntoView();
+              const headerHeight = document.querySelector('header.site-header').offsetHeight;
+              window.scrollBy(0,-(headerHeight))}
+            } key={i}>{section.value}</HashLink>)
           })}
           </div>
         </nav>


### PR DESCRIPTION
This might need the [Smooth Scroll Behavior](https://github.com/iamdustan/smoothscroll) polyfill some day if I ever want to implement smooth scrolling to anchors.

I'm not happy that I have to do an `el.scrollIntoView()` followed by `window.scrollBy()` in order to account for the fixed header height, but it seems like the best way to implement this feature at the moment.

Also updated footer credits.